### PR TITLE
Refetchable async select, person & report tweaks

### DIFF
--- a/src/components/FormSelectAsync.tsx
+++ b/src/components/FormSelectAsync.tsx
@@ -56,6 +56,7 @@ interface FormSelectAsyncProps {
     data?: { data: any[]; meta?: { last_page?: number } };
     isLoading: boolean;
     isFetching?: boolean;
+    refetch?: () => void;
   };
   mapOptionFn: (item: any) => Option;
   perPage?: number;
@@ -68,6 +69,7 @@ interface FormSelectAsyncProps {
   externalOption?: Option | null;
   horizontalField?: boolean; // Nueva prop para forzar layout horizontal
   descriptionAsBadge?: boolean;
+  refetchOnOpen?: boolean;
 }
 
 function getOptionLabel(opt: Option): string {
@@ -100,6 +102,7 @@ export function FormSelectAsync({
   externalOption,
   horizontalField = false,
   descriptionAsBadge = false,
+  refetchOnOpen = false,
 }: FormSelectAsyncProps) {
   const { horizontal } = useFormLayout();
   const { field: controlField } = useController({ name, control });
@@ -151,7 +154,7 @@ export function FormSelectAsync({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [externalOption?.value]);
 
-  const { data, isLoading, isFetching } = useQueryHook({
+  const { data, isLoading, isFetching, refetch } = useQueryHook({
     search: debouncedSearch,
     page,
     per_page: perPage,
@@ -278,6 +281,7 @@ export function FormSelectAsync({
         }
         setAllOptions(newOptions);
       }
+      if (refetchOnOpen) refetch?.();
     } else {
       setDebouncedSearch("");
       setAllOptions([]);
@@ -412,6 +416,7 @@ export function FormSelectAsync({
                                   }
                                   setAllOptions(newOptions);
                                 }
+                                if (refetchOnOpen) refetch?.();
                               } else {
                                 setDebouncedSearch("");
                                 setAllOptions([]);

--- a/src/pages/person/components/PersonForm.tsx
+++ b/src/pages/person/components/PersonForm.tsx
@@ -59,7 +59,6 @@ interface NumberDocumentContentProps {
   fieldsFromSearch: { names: boolean };
   dirtyFields: any;
   document_type_id: string;
-  isClient: boolean;
   isSearching: boolean;
   handleDocumentSearch: () => void;
 }
@@ -70,18 +69,12 @@ function NumberDocumentContent({
   fieldsFromSearch,
   dirtyFields,
   document_type_id,
-  isClient,
   isSearching,
   handleDocumentSearch,
 }: NumberDocumentContentProps) {
   const { horizontal } = useFormLayout();
 
-  const labelText = (
-    <>
-      Número de Documento {!isClient && errors.number_document && "*"}
-      {isClient && " (Opcional)"}
-    </>
-  );
+  const labelText = <>Número de Documento (Opcional)</>;
 
   const inputEl = (
     <FormControl>
@@ -228,7 +221,7 @@ export const PersonForm = ({
   const form = useForm<FormSchema>({
     resolver: zodResolver(schema),
     defaultValues: {
-      document_type_id: initialData?.document_type_id?.toString() || "",
+      document_type_id: initialData?.document_type_id?.toString() || TYPE_DOCUMENT.DNI.id,
       type_person:
         (initialData?.type_person as "NATURAL" | "JURIDICA") || "NATURAL",
       number_document: initialData?.number_document ?? "",
@@ -495,7 +488,6 @@ export const PersonForm = ({
                 fieldsFromSearch={fieldsFromSearch}
                 dirtyFields={dirtyFields}
                 document_type_id={document_type_id}
-                isClient={isClient}
                 isSearching={isSearching}
                 handleDocumentSearch={handleDocumentSearch}
               />
@@ -526,6 +518,7 @@ export const PersonForm = ({
                 name="names"
                 label="Nombres"
                 placeholder="Ingrese los nombres"
+                uppercase
                 className={
                   fieldsFromSearch.names ? "bg-blue-50 border-blue-200" : ""
                 }
@@ -536,6 +529,7 @@ export const PersonForm = ({
                 name="father_surname"
                 label="Apellido Paterno"
                 placeholder="Ingrese apellido paterno"
+                uppercase
                 className={fieldsFromSearch.father_surname ? "bg-blue-50" : ""}
               />
 
@@ -544,6 +538,7 @@ export const PersonForm = ({
                 name="mother_surname"
                 label="Apellido Materno"
                 placeholder="Ingrese apellido materno"
+                uppercase
                 className={fieldsFromSearch.mother_surname ? "bg-blue-50" : ""}
               />
 

--- a/src/pages/person/lib/person.schema.ts
+++ b/src/pages/person/lib/person.schema.ts
@@ -180,19 +180,6 @@ export const createPersonSchema = (
       role_id: requiredStringId("Debe seleccionar un rol válido"),
     })
     .superRefine((data, ctx) => {
-      // Validación condicional para number_document
-      // Si NO es Cliente, el número de documento es obligatorio
-      if (!isClient) {
-        if (!data.number_document || data.number_document.trim() === "") {
-          ctx.addIssue({
-            code: "invalid_type",
-            expected: "string",
-            message: "El número de documento es obligatorio",
-            path: ["number_document"],
-          });
-        }
-      }
-
       if (isDriver) {
         if (!data.driver_license || data.driver_license.trim() === "") {
           ctx.addIssue({
@@ -263,25 +250,6 @@ export const createPersonSchema = (
             code: "custom",
             message: "El nombre solo puede contener letras y espacios",
             path: ["names"],
-          });
-        }
-
-        if (!data.father_surname || data.father_surname.trim() === "") {
-          ctx.addIssue({
-            code: "invalid_type",
-            expected: "string",
-            message:
-              "El apellido paterno es obligatorio para personas naturales",
-            path: ["father_surname"],
-          });
-        }
-        if (!data.mother_surname || data.mother_surname.trim() === "") {
-          ctx.addIssue({
-            code: "invalid_type",
-            expected: "string",
-            message:
-              "El apellido materno es obligatorio para personas naturales",
-            path: ["mother_surname"],
           });
         }
 

--- a/src/pages/reports/components/DetailedSalesReportPage.tsx
+++ b/src/pages/reports/components/DetailedSalesReportPage.tsx
@@ -27,6 +27,10 @@ interface FilterFormValues {
   warehouse_id: string;
   start_date: string;
   end_date: string;
+  zone_id: string;
+  brand_id: string;
+  product_id: string;
+  line: string;
 }
 
 export default function DetailedSalesReportPage() {
@@ -45,6 +49,10 @@ export default function DetailedSalesReportPage() {
       warehouse_id: "",
       start_date: today,
       end_date: today,
+      zone_id: "",
+      brand_id: "",
+      product_id: "",
+      line: "",
     },
   });
 
@@ -63,6 +71,10 @@ export default function DetailedSalesReportPage() {
     warehouse_id: values.warehouse_id ? Number(values.warehouse_id) : null,
     start_date: values.start_date || null,
     end_date: values.end_date || null,
+    zone_id: values.zone_id ? Number(values.zone_id) : null,
+    brand_id: values.brand_id ? Number(values.brand_id) : null,
+    product_id: values.product_id ? Number(values.product_id) : null,
+    line: values.line || null,
   });
 
   const handleExcelExport = async () => {

--- a/src/pages/reports/lib/reports.interface.ts
+++ b/src/pages/reports/lib/reports.interface.ts
@@ -608,6 +608,10 @@ export interface DetailedSalesReportParams {
   start_date?: string | null;
   user_id?: number | null;
   warehouse_id?: number | null;
+  zone_id?: number | null;
+  brand_id?: number | null;
+  product_id?: number | null;
+  line?: string | null;
 }
 
 export interface DetailedSaleItem {

--- a/src/pages/sale/components/SaleForm.tsx
+++ b/src/pages/sale/components/SaleForm.tsx
@@ -9,7 +9,7 @@ import {
   saleSchemaUpdate,
   type SaleSchema,
 } from "../lib/sale.schema";
-import { Users2, CreditCard, ListChecks, Users, FileText } from "lucide-react";
+import { Users2, CreditCard, ListChecks, Users, FileText, Copy, Check } from "lucide-react";
 import { FormSelect } from "@/components/FormSelect";
 import { FormSelectAsync } from "@/components/FormSelectAsync";
 import { DatePickerFormField } from "@/components/DatePickerFormField";
@@ -142,6 +142,8 @@ export const SaleForm = ({
       return "";
     },
   );
+
+  const [copiedCustomer, setCopiedCustomer] = useState(false);
 
   const { fetchDynamicPrice } = useDynamicPrice();
   const queryClient = useQueryClient();
@@ -345,6 +347,14 @@ export const SaleForm = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedBranchId, warehouses]);
+
+  const handleCopyCustomerName = useCallback(() => {
+    if (!selectedCustomerName) return;
+    navigator.clipboard.writeText(selectedCustomerName).then(() => {
+      setCopiedCustomer(true);
+      setTimeout(() => setCopiedCustomer(false), 2000);
+    });
+  }, [selectedCustomerName]);
 
   // Actualizar direcciones al seleccionar un cliente en el FormSelectAsync
   const handleCustomerChange = async (
@@ -1228,7 +1238,9 @@ export const SaleForm = ({
                   value: customer.id.toString(),
                   label:
                     customer.business_name ||
-                    `${customer.names} ${customer.father_surname} ${customer.mother_surname}`.trim(),
+                    [customer.names, customer.father_surname, customer.mother_surname]
+                      .filter(Boolean)
+                      .join(" "),
                   description:
                     getCustomerZoneLabel(customer) +
                     (customer.number_document
@@ -1251,9 +1263,25 @@ export const SaleForm = ({
                 }
                 disabled={mode === "update"}
                 uppercase
+                refetchOnOpen
                 externalOption={externalCustomerOption}
               />
             </div>
+            {selectedCustomerName && (
+              <Button
+                type="button"
+                size="icon"
+                variant="outline"
+                onClick={handleCopyCustomerName}
+                title="Copiar nombre del cliente"
+              >
+                {copiedCustomer ? (
+                  <Check className="h-4 w-4 text-green-500" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+              </Button>
+            )}
             <Button
               type="button"
               size="icon"


### PR DESCRIPTION
Add refetchOnOpen to FormSelectAsync and call useQueryHook.refetch when the dropdown is opened (optional behavior). Update SaleForm to enable refetchOnOpen for the customer select, format customer name join logic, and add a copy-to-clipboard button with visual feedback. Make person form fields more permissive: default document_type_id to DNI, remove isClient-dependent required validation and strict surname requirements in the schema, and mark name/surname inputs to uppercase. Extend Detailed Sales Report filters and types to include zone_id, brand_id, product_id and line and map form values to the new params. Minor imports and state/hooks added where needed.