### PR TITLE
Enforce doc/total rule and use DOCUMENT_TYPES

### DIFF
--- a/src/components/SearchableSelect.tsx
+++ b/src/components/SearchableSelect.tsx
@@ -29,7 +29,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import type { Option } from "@/lib/core.interface";
 
 interface SearchableSelectProps {
-  options: Option[];
+  options: readonly Option[];
   value: string;
   onChange: (value: string) => void;
   onBlur?: () => void;

--- a/src/pages/reports/components/SaleTicketsPrintPage.tsx
+++ b/src/pages/reports/components/SaleTicketsPrintPage.tsx
@@ -18,15 +18,12 @@ import {
   getSalesByRange,
   exportBulkTickets,
 } from "@/pages/sale/lib/sale.actions";
-import type { SaleResource } from "@/pages/sale/lib/sale.interface";
+import {
+  DOCUMENT_TYPES,
+  type SaleResource,
+} from "@/pages/sale/lib/sale.interface";
 import { errorToast, promiseToast } from "@/lib/core.function";
 import { FormInput } from "@/components/FormInput";
-
-const DOCUMENT_TYPE_OPTIONS = [
-  { value: "BOLETA", label: "Boleta" },
-  { value: "FACTURA", label: "Factura" },
-  { value: "TICKET", label: "Ticket" },
-];
 
 export default function SaleTicketsPrintPage() {
   const [searchParams, setSearchParams] = useState({
@@ -121,7 +118,7 @@ export default function SaleTicketsPrintPage() {
       >
         <SearchableSelect
           label="Tipo de documento"
-          options={DOCUMENT_TYPE_OPTIONS}
+          options={DOCUMENT_TYPES}
           value={searchParams.document_type}
           onChange={(val) =>
             setSearchParams({ ...searchParams, document_type: val })

--- a/src/pages/sale/components/SaleForm.tsx
+++ b/src/pages/sale/components/SaleForm.tsx
@@ -144,6 +144,14 @@ export const SaleForm = ({
   );
 
   const [copiedCustomer, setCopiedCustomer] = useState(false);
+  const [selectedCustomerDocument, setSelectedCustomerDocument] = useState<
+    string | null
+  >(() => {
+    if (mode === "update" && sale?.customer) {
+      return sale.customer.number_document ?? null;
+    }
+    return null;
+  });
 
   const { fetchDynamicPrice } = useDynamicPrice();
   const queryClient = useQueryClient();
@@ -372,6 +380,7 @@ export const SaleForm = ({
         resolvedItem.business_name ||
           `${resolvedItem.names ?? ""} ${resolvedItem.father_surname ?? ""} ${resolvedItem.mother_surname ?? ""}`.trim(),
       );
+      setSelectedCustomerDocument(resolvedItem.number_document ?? null);
     }
     const personId = resolvedItem?.id ?? Number(_value);
 
@@ -1040,6 +1049,17 @@ export const SaleForm = ({
     if (selectedPaymentType === "CREDITO" && installments.length === 0) {
       errorToast("Para pagos a crédito, debe agregar al menos una cuota");
       return;
+    }
+
+    // Validar que clientes sin documento no superen S/. 700
+    if (!selectedCustomerDocument) {
+      const total = calculateDetailsTotal();
+      if (total > 700) {
+        warningToast(
+          `No se puede registrar una venta mayor a S/. 700.00 para clientes sin número de documento. Total actual: S/. ${formatNumber(total)}`,
+        );
+        return;
+      }
     }
 
     // Validar que las cuotas coincidan con el total si hay cuotas


### PR DESCRIPTION
Make SearchableSelect.options readonly for stronger typing. Replace the local DOCUMENT_TYPE_OPTIONS with the shared DOCUMENT_TYPES constant in SaleTicketsPrintPage. In SaleForm add selectedCustomerDocument state (initialized when updating a sale and updated on customer selection) and validate on save that customers without a document cannot have sales > S/.700 — show a warning toast and abort save if violated. These changes centralize document options and enforce a fiscal/business constraint.