### PR TITLE
Support sale selection & bulk credit-note tickets

### DIFF
--- a/src/pages/credit-note/components/CreditNoteOptions.tsx
+++ b/src/pages/credit-note/components/CreditNoteOptions.tsx
@@ -8,7 +8,9 @@ import { useAllCreditNoteMotives } from "@/pages/credit-note-motive/lib/credit-n
 import { CREDIT_NOTE_STATUSES } from "../lib/credit-note.interface";
 import { SearchableSelectAsync } from "@/components/SearchableSelectAsync";
 import { useClients } from "@/pages/client/lib/client.hook";
+import { useSale } from "@/pages/sale/lib/sale.hook";
 import type { PersonResource } from "@/pages/person/lib/person.interface";
+import type { SaleResource } from "@/pages/sale/lib/sale.interface";
 import {
   Select,
   SelectContent,
@@ -16,8 +18,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { buttonVariants } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { FilePlus } from "lucide-react";
 
 type ActiveFilter = "" | "customer" | "motive" | "status";
 
@@ -33,6 +36,10 @@ interface CreditNoteOptionsProps {
   issue_date_from?: Date;
   issue_date_to?: Date;
   onDateChange: (from: Date | undefined, to: Date | undefined) => void;
+  sale_id: string;
+  setSaleId: (value: string) => void;
+  onSaleValueChange?: (value: string, item?: SaleResource) => void;
+  onGenerateCreditNote?: () => void;
 }
 
 export default function CreditNoteOptions({
@@ -47,6 +54,10 @@ export default function CreditNoteOptions({
   issue_date_from,
   issue_date_to,
   onDateChange,
+  sale_id,
+  setSaleId,
+  onSaleValueChange,
+  onGenerateCreditNote,
 }: CreditNoteOptionsProps) {
   const { data: motives = [] } = useAllCreditNoteMotives();
   const [activeFilter, setActiveFilter] = useState<ActiveFilter>("");
@@ -140,6 +151,37 @@ export default function CreditNoteOptions({
           onChange={setStatus}
           placeholder="Estado"
         />
+      )}
+
+      <SearchableSelectAsync
+        useQueryHook={useSale}
+        mapOptionFn={(sale: SaleResource) => ({
+          value: String(sale.id),
+          label: sale.full_document_number,
+          description:
+            sale.customer?.business_name ||
+            `${sale.customer?.names ?? ""} ${sale.customer?.father_surname ?? ""}`.trim(),
+        })}
+        value={sale_id}
+        onChange={(val) => {
+          setSaleId(val);
+          if (!val && onSaleValueChange) onSaleValueChange("", undefined);
+        }}
+        onValueChange={onSaleValueChange}
+        placeholder="N° de Venta"
+        className="w-[200px] bg-accent"
+      />
+
+      {sale_id && onGenerateCreditNote && (
+        <Button
+          size="sm"
+          variant="outline"
+          colorIcon="green"
+          onClick={onGenerateCreditNote}
+        >
+          <FilePlus className="h-4 w-4" />
+          Nueva Nota de Crédito
+        </Button>
       )}
     </div>
   );

--- a/src/pages/credit-note/components/CreditNotePage.tsx
+++ b/src/pages/credit-note/components/CreditNotePage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useCreditNote } from "../lib/credit-note.hook";
 import type { RowSelectionState } from "@tanstack/react-table";
+import type { SaleResource } from "@/pages/sale/lib/sale.interface";
 
 import CreditNoteActions from "./CreditNoteActions";
 import CreditNoteTable from "./CreditNoteTable";
@@ -24,10 +26,13 @@ import PageWrapper from "@/components/PageWrapper";
 const { MODEL } = CREDIT_NOTE;
 
 export default function CreditNotePage() {
+  const navigate = useNavigate();
   const [search, setSearch] = useState("");
   const [status, setStatus] = useState("");
   const [motive_id, setMotiveId] = useState("");
   const [customer_id, setCustomerId] = useState("");
+  const [sale_id, setSaleId] = useState("");
+  const [selectedSale, setSelectedSale] = useState<SaleResource | null>(null);
   const [issue_date_from, setIssueDateFrom] = useState<Date | undefined>();
   const [issue_date_to, setIssueDateTo] = useState<Date | undefined>();
   const [page, setPage] = useState(1);
@@ -58,6 +63,11 @@ export default function CreditNotePage() {
   useEffect(() => {
     refetch(buildParams());
   }, [page, per_page, search, status, motive_id, customer_id, issue_date_from, issue_date_to]);
+
+  const handleGenerateCreditNote = () => {
+    if (!selectedSale) return;
+    navigate(CREDIT_NOTE.ROUTE_ADD, { state: { sale: selectedSale } });
+  };
 
   const selectedNoteId = Object.keys(rowSelection).find((key) => rowSelection[key]);
   const toolbarNote = selectedNoteId
@@ -150,6 +160,10 @@ export default function CreditNotePage() {
             setIssueDateFrom(from);
             setIssueDateTo(to);
           }}
+          sale_id={sale_id}
+          setSaleId={setSaleId}
+          onSaleValueChange={(_val, item) => setSelectedSale(item ?? null)}
+          onGenerateCreditNote={handleGenerateCreditNote}
         />
       </CreditNoteTable>
 

--- a/src/pages/credit-note/lib/credit-note.actions.ts
+++ b/src/pages/credit-note/lib/credit-note.actions.ts
@@ -60,6 +60,54 @@ export async function getCreditNoteTicket(id: number): Promise<Blob> {
   return response.data;
 }
 
+// Tickets en bulk
+export interface BulkCreditNoteTicketsRequest {
+  document_series: string;
+  numero_inicio: number;
+  numero_fin: number;
+}
+
+export async function exportBulkCreditNoteTickets(
+  params: BulkCreditNoteTicketsRequest
+): Promise<Blob> {
+  const response = await api.post(
+    `/credit-notes/bulk-ticket`,
+    params,
+    { responseType: "blob" }
+  );
+  return response.data;
+}
+
+// Buscar por rango de números
+export interface GetCreditNotesByRangeParams {
+  serie?: string;
+  numero_inicio: string;
+  numero_fin: string;
+}
+
+export interface CreditNotesByRangeResponse {
+  message: string;
+  data: CreditNoteResource[];
+  meta: {
+    total: number;
+    rango_solicitado: {
+      serie: string;
+      numero_inicio: string;
+      numero_fin: string;
+    };
+  };
+}
+
+export async function getCreditNotesByRange(
+  params: GetCreditNotesByRangeParams
+): Promise<CreditNotesByRangeResponse> {
+  const response = await api.post<CreditNotesByRangeResponse>(
+    `${ENDPOINT}/by-range`,
+    params
+  );
+  return response.data;
+}
+
 // Actualizar
 export async function updateCreditNote(
   id: number,

--- a/src/pages/reports/components/SaleTicketsPrintPage.tsx
+++ b/src/pages/reports/components/SaleTicketsPrintPage.tsx
@@ -18,12 +18,20 @@ import {
   getSalesByRange,
   exportBulkTickets,
 } from "@/pages/sale/lib/sale.actions";
-import {
-  DOCUMENT_TYPES,
-  type SaleResource,
-} from "@/pages/sale/lib/sale.interface";
+import { DOCUMENT_TYPES } from "@/pages/sale/lib/sale.interface";
 import { errorToast, promiseToast } from "@/lib/core.function";
 import { FormInput } from "@/components/FormInput";
+import { exportBulkCreditNoteTickets } from "@/pages/credit-note/lib/credit-note.actions";
+
+interface DisplayItem {
+  id: number;
+  full_document_number: string;
+  document_type: string;
+  customer_name: string;
+  issue_date: string;
+  currency: string;
+  total_amount: number;
+}
 
 export default function SaleTicketsPrintPage() {
   const [searchParams, setSearchParams] = useState({
@@ -32,10 +40,12 @@ export default function SaleTicketsPrintPage() {
     numero_inicio: "",
     numero_fin: "",
   });
-  const [salesByRange, setSalesByRange] = useState<SaleResource[]>([]);
-  const [selectedSales, setSelectedSales] = useState<number[]>([]);
+  const [items, setItems] = useState<DisplayItem[]>([]);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [isPrinting, setIsPrinting] = useState(false);
+
+  const isCreditNote = searchParams.document_type === "NOTA_CREDITO";
 
   const handleSearch = async () => {
     if (!searchParams.numero_inicio || !searchParams.numero_fin) {
@@ -54,60 +64,99 @@ export default function SaleTicketsPrintPage() {
       const response = await getSalesByRange(params);
       if (response.data.length === 0) {
         errorToast("No se encontraron ventas en el rango especificado");
-        setSalesByRange([]);
-        setSelectedSales([]);
+        setItems([]);
+        setSelectedIds([]);
         return;
       }
-      setSalesByRange(response.data);
-      setSelectedSales(response.data.map((s) => s.id));
+      const mapped: DisplayItem[] = response.data.map((s) => ({
+        id: s.id,
+        full_document_number: s.full_document_number,
+        document_type: s.document_type,
+        customer_name:
+          s.customer.business_name ||
+          `${s.customer.names} ${s.customer.father_surname}`,
+        issue_date: s.issue_date,
+        currency: s.currency,
+        total_amount: s.total_amount,
+      }));
+      setItems(mapped);
+      setSelectedIds(mapped.map((i) => i.id));
     } catch (error: any) {
       errorToast(error.response?.data?.message || "Error al buscar ventas");
-      setSalesByRange([]);
-      setSelectedSales([]);
+      setItems([]);
+      setSelectedIds([]);
     } finally {
       setIsSearching(false);
     }
   };
 
-  const handleToggleSale = (id: number) => {
-    setSelectedSales((prev) =>
+  const handlePrintCreditNote = () => {
+    if (!searchParams.numero_inicio || !searchParams.numero_fin) {
+      errorToast("Complete los campos de número inicio y fin");
+      return;
+    }
+
+    setIsPrinting(true);
+
+    const printPromise = exportBulkCreditNoteTickets({
+      document_series: searchParams.serie,
+      numero_inicio: Number(searchParams.numero_inicio),
+      numero_fin: Number(searchParams.numero_fin),
+    }).then((blob) => {
+      const url = window.URL.createObjectURL(blob);
+      window.open(url, "_blank");
+    });
+
+    promiseToast(printPromise, {
+      loading: "Generando ticket...",
+      success: "Ticket generado correctamente",
+      error: (err: any) => err?.message || "Error al generar ticket",
+    });
+
+    printPromise.finally(() => setIsPrinting(false));
+  };
+
+  const handleToggleItem = (id: number) => {
+    setSelectedIds((prev) =>
       prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
     );
   };
 
   const handleToggleAll = () => {
-    if (selectedSales.length === salesByRange.length) {
-      setSelectedSales([]);
+    if (selectedIds.length === items.length) {
+      setSelectedIds([]);
     } else {
-      setSelectedSales(salesByRange.map((s) => s.id));
+      setSelectedIds(items.map((i) => i.id));
     }
   };
 
-  const handlePrint = () => {
-    if (selectedSales.length === 0) {
+  const handlePrintSales = () => {
+    if (selectedIds.length === 0) {
       errorToast("No hay ventas seleccionadas");
       return;
     }
 
     setIsPrinting(true);
-    const downloadPromise = exportBulkTickets(selectedSales).then((blob) => {
+    const downloadPromise = exportBulkTickets(selectedIds).then((blob) => {
       const url = window.URL.createObjectURL(blob);
       window.open(url, "_blank");
     });
 
     promiseToast(downloadPromise, {
       loading: "Generando tickets...",
-      success: `${selectedSales.length} ticket(s) generado(s) correctamente`,
+      success: `${selectedIds.length} ticket(s) generado(s) correctamente`,
       error: "Error al generar tickets",
     });
 
     downloadPromise.finally(() => setIsPrinting(false));
   };
 
-  const allSelected =
-    salesByRange.length > 0 && selectedSales.length === salesByRange.length;
+  const allSelected = items.length > 0 && selectedIds.length === items.length;
   const someSelected =
-    selectedSales.length > 0 && selectedSales.length < salesByRange.length;
+    selectedIds.length > 0 && selectedIds.length < items.length;
+
+  const creditNotePrintDisabled =
+    isPrinting || !searchParams.numero_inicio || !searchParams.numero_fin;
 
   return (
     <PageWrapper>
@@ -121,7 +170,12 @@ export default function SaleTicketsPrintPage() {
           options={DOCUMENT_TYPES}
           value={searchParams.document_type}
           onChange={(val) =>
-            setSearchParams({ ...searchParams, document_type: val })
+            setSearchParams({
+              document_type: val,
+              serie: "",
+              numero_inicio: "",
+              numero_fin: "",
+            })
           }
           placeholder="Tipo de documento"
           className="w-full!"
@@ -144,10 +198,7 @@ export default function SaleTicketsPrintPage() {
           type="number"
           value={searchParams.numero_inicio}
           onChange={(e) =>
-            setSearchParams({
-              ...searchParams,
-              numero_inicio: e.target.value,
-            })
+            setSearchParams({ ...searchParams, numero_inicio: e.target.value })
           }
           placeholder="Ej: 1"
           className="h-8"
@@ -166,22 +217,26 @@ export default function SaleTicketsPrintPage() {
         />
 
         <div className="flex justify-end items-end h-full gap-2">
+          {!isCreditNote && (
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={handleSearch}
+              disabled={isSearching}
+            >
+              {isSearching ? (
+                <Loader className="h-4 w-4 animate-spin" />
+              ) : (
+                <Search className="h-4 w-4" />
+              )}
+              Buscar
+            </Button>
+          )}
           <Button
-            size="sm"
-            variant="secondary"
-            onClick={handleSearch}
-            disabled={isSearching}
-          >
-            {isSearching ? (
-              <Loader className="h-4 w-4 animate-spin" />
-            ) : (
-              <Search className="h-4 w-4" />
-            )}
-            Buscar
-          </Button>
-          <Button
-            onClick={handlePrint}
-            disabled={isPrinting || selectedSales.length === 0}
+            onClick={isCreditNote ? handlePrintCreditNote : handlePrintSales}
+            disabled={
+              isCreditNote ? creditNotePrintDisabled : isPrinting || selectedIds.length === 0
+            }
           >
             {isPrinting ? (
               <Loader className="h-4 w-4 animate-spin" />
@@ -189,14 +244,14 @@ export default function SaleTicketsPrintPage() {
               <Printer className="h-4 w-4" />
             )}
             Imprimir
-            {selectedSales.length > 0 && ` (${selectedSales.length})`}
+            {!isCreditNote && selectedIds.length > 0 && ` (${selectedIds.length})`}
           </Button>
         </div>
       </GroupFormSection>
 
-      {salesByRange.length > 0 && (
+      {!isCreditNote && items.length > 0 && (
         <GroupFormSection
-          title={`Ventas encontradas (${salesByRange.length})`}
+          title={`Ventas encontradas (${items.length})`}
           icon={Filter}
           cols={{ sm: 1 }}
         >
@@ -224,44 +279,41 @@ export default function SaleTicketsPrintPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {salesByRange.map((sale) => (
+                {items.map((item) => (
                   <TableRow
-                    key={sale.id}
+                    key={item.id}
                     className={`cursor-pointer hover:bg-muted/30 ${
-                      selectedSales.includes(sale.id) ? "bg-muted/50" : ""
+                      selectedIds.includes(item.id) ? "bg-muted/50" : ""
                     }`}
-                    onClick={() => handleToggleSale(sale.id)}
+                    onClick={() => handleToggleItem(item.id)}
                   >
                     <TableCell onClick={(e) => e.stopPropagation()}>
                       <Checkbox
-                        checked={selectedSales.includes(sale.id)}
-                        onCheckedChange={() => handleToggleSale(sale.id)}
+                        checked={selectedIds.includes(item.id)}
+                        onCheckedChange={() => handleToggleItem(item.id)}
                         className="cursor-pointer"
                       />
                     </TableCell>
                     <TableCell>
                       <div>
                         <div className="font-medium">
-                          {sale.full_document_number}
+                          {item.full_document_number}
                         </div>
                         <div className="text-xs text-muted-foreground">
-                          {sale.document_type}
+                          {item.document_type}
                         </div>
                       </div>
                     </TableCell>
+                    <TableCell>{item.customer_name}</TableCell>
                     <TableCell>
-                      {sale.customer.business_name ||
-                        `${sale.customer.names} ${sale.customer.father_surname}`}
-                    </TableCell>
-                    <TableCell>
-                      {new Date(sale.issue_date).toLocaleDateString("es-PE", {
+                      {new Date(item.issue_date).toLocaleDateString("es-PE", {
                         year: "numeric",
                         month: "2-digit",
                         day: "2-digit",
                       })}
                     </TableCell>
                     <TableCell className="text-right">
-                      {sale.currency} {sale.total_amount.toFixed(2)}
+                      {item.currency} {item.total_amount.toFixed(2)}
                     </TableCell>
                   </TableRow>
                 ))}
@@ -269,10 +321,10 @@ export default function SaleTicketsPrintPage() {
             </Table>
           </div>
 
-          {selectedSales.length > 0 && (
+          {selectedIds.length > 0 && (
             <div className="p-3 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg">
               <p className="text-sm font-medium text-blue-900 dark:text-blue-100">
-                {selectedSales.length} venta(s) seleccionada(s) para imprimir
+                {selectedIds.length} venta(s) seleccionada(s) para imprimir
               </p>
             </div>
           )}


### PR DESCRIPTION
Add sale search/select UI to CreditNoteOptions (useSale hook, SaleResource typing, FilePlus button) and expose sale_id/handlers to CreditNotePage to navigate to credit-note creation with selected sale. Implement new API actions: exportBulkCreditNoteTickets and getCreditNotesByRange (request/response types). Revamp SaleTicketsPrintPage to support printing credit-note tickets by single number, introduce unified item mapping/display type, update selection state/handlers, conditional form inputs/UI for credit notes vs sales, and wire up export functions and toasts for both flows.