### PR TITLE
Remove motive selection and simplify credit note form

### DIFF
--- a/src/pages/credit-note/components/CreditNoteAddPage.tsx
+++ b/src/pages/credit-note/components/CreditNoteAddPage.tsx
@@ -17,7 +17,6 @@ import { useCreditNoteStore } from "../lib/credit-note.store";
 import { getCreditNoteTicket } from "../lib/credit-note.actions";
 import FormSkeleton from "@/components/FormSkeleton";
 import { useAllSales } from "@/pages/sale/lib/sale.hook";
-import { useAllCreditNoteMotives } from "@/pages/credit-note-motive/lib/credit-note-motive.hook";
 import PageWrapper from "@/components/PageWrapper";
 import { ConfirmationDialog } from "@/components/ConfirmationDialog";
 
@@ -37,10 +36,7 @@ export default function CreditNoteAddPage() {
   const [showPrintDialog, setShowPrintDialog] = useState(false);
   const [pendingCreditNoteId, setPendingCreditNoteId] = useState<number | null>(null);
 
-  // Obtener ventas (solo necesario cuando no hay venta preseleccionada) y motivos
   const { data: sales, isLoading: isLoadingSales } = useAllSales();
-  const { data: motives, isLoading: isLoadingMotives } =
-    useAllCreditNoteMotives();
 
   // Obtener la venta seleccionada
   const selectedSale = useMemo(
@@ -70,17 +66,6 @@ export default function CreditNoteAddPage() {
             };
           }) || [],
     [isReadOnlySale, sales],
-  );
-
-  const motivesOptions = useMemo(
-    () =>
-      motives
-        ?.filter((motive) => motive.id === 1 || motive.id === 7)
-        .map((motive) => ({
-          value: motive.id.toString(),
-          label: `${motive.code} - ${motive.name}`,
-        })) || [],
-    [motives],
   );
 
   const handleSubmit = async (data: CreditNoteSchema) => {
@@ -137,8 +122,7 @@ export default function CreditNoteAddPage() {
     navigate(ROUTE);
   };
 
-  // Mostrar skeleton mientras cargan los datos
-  if ((isReadOnlySale ? false : isLoadingSales) || isLoadingMotives) {
+  if (!isReadOnlySale && isLoadingSales) {
     return (
       <PageWrapper>
         <FormSkeleton />
@@ -156,7 +140,6 @@ export default function CreditNoteAddPage() {
         onCancel={() => navigate(ROUTE)}
         isSubmitting={isSubmitting}
         sales={salesOptions}
-        motives={motivesOptions}
         selectedSale={selectedSale}
         onSaleChange={setSelectedSaleId}
         readOnlySale={isReadOnlySale}

--- a/src/pages/credit-note/components/CreditNoteColumns.tsx
+++ b/src/pages/credit-note/components/CreditNoteColumns.tsx
@@ -30,11 +30,11 @@ export const CreditNoteColumns = (): ColumnDef<CreditNoteResource>[] => [
     cell: ({ row }) => {
       const sale = row.original.sale;
       return (
-        <div className="flex flex-col gap-1">
-          <Badge variant="outline" className="font-mono w-fit">
+        <div className="flex flex-col">
+          <span className="font-mono font-bold text-sm text-muted-foreground leading-none">
             {sale.serie}-{sale.numero}
-          </Badge>
-          <span className="text-xs text-muted-foreground">
+          </span>
+          <span className="text-xs text-muted-foreground leading-none">
             {sale.document_type}
           </span>
         </div>
@@ -59,16 +59,11 @@ export const CreditNoteColumns = (): ColumnDef<CreditNoteResource>[] => [
     },
   },
   {
-    accessorKey: "motive",
+    accessorKey: "reason",
     header: "Motivo",
     cell: ({ row }) => {
-      const motive = row.original.motive;
-      return (
-        <div className="flex flex-col gap-1">
-          <span className="font-semibold">{motive?.name}</span>
-          <span className="text-xs text-muted-foreground">{motive?.code}</span>
-        </div>
-      );
+      const motive = row.original.reason;
+      return <Badge variant="outline">{motive}</Badge>;
     },
   },
   {

--- a/src/pages/credit-note/components/CreditNoteForm.tsx
+++ b/src/pages/credit-note/components/CreditNoteForm.tsx
@@ -31,7 +31,6 @@ interface CreditNoteFormProps {
   onCancel?: () => void;
   isSubmitting?: boolean;
   sales?: Array<{ value: string; label: string }>;
-  motives?: Array<{ value: string; label: string }>;
   selectedSale?: SaleResource | null;
   onSaleChange?: (saleId: number | null) => void;
   readOnlySale?: boolean;
@@ -122,7 +121,6 @@ export const CreditNoteForm = ({
   onCancel,
   isSubmitting = false,
   sales = [],
-  motives = [],
   selectedSale,
   onSaleChange,
   readOnlySale = false,
@@ -159,9 +157,6 @@ export const CreditNoteForm = ({
     mode: "onChange",
   });
 
-  const watchMotiveId = form.watch("credit_note_motive_id");
-  const isAnulacion = watchMotiveId === "1";
-
   const watchSaleId = form.watch("sale_id");
 
   useEffect(() => {
@@ -197,20 +192,14 @@ export const CreditNoteForm = ({
           return calcRow(base);
         },
       );
-      // Si es Anulación, cargar todas las cantidades; si es Devolución, iniciar vacío
-      if (isAnulacion) {
-        setDetails(rows);
-        syncFormDetails(rows);
-      } else {
-        setDetails([]);
-        form.setValue("details", []);
-      }
+      setDetails(rows);
+      syncFormDetails(rows);
     } else {
       setDetails([]);
       form.setValue("details", []);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedSale, isAnulacion]);
+  }, [selectedSale]);
 
   const syncFormDetails = (rows: CreditNoteDetailRow[]) => {
     form.setValue(
@@ -241,11 +230,6 @@ export const CreditNoteForm = ({
   };
 
   const handleRemoveRow = (index: number) => {
-    if (isAnulacion) {
-      warningToast("No se pueden quitar filas en Anulación de la operación");
-      return;
-    }
-    
     setDetails((prev) => {
       const updated = prev
         .filter((_, i) => i !== index)
@@ -256,11 +240,6 @@ export const CreditNoteForm = ({
   };
 
   const handleAddRow = () => {
-    if (isAnulacion) {
-      warningToast("No se pueden agregar filas en Anulación de la operación");
-      return;
-    }
-
     if (!selectedSale?.details?.length) {
       warningToast("Seleccione una venta con productos para agregar otra línea");
       return;
@@ -407,7 +386,6 @@ export const CreditNoteForm = ({
       type: "product-code",
       width: "100px",
       accessor: "product_code",
-      disabled: () => isAnulacion,
     },
     {
       id: "product_name",
@@ -415,7 +393,6 @@ export const CreditNoteForm = ({
       type: "product-search",
       width: "320px",
       accessor: "product_name",
-      disabled: () => isAnulacion,
     },
     {
       id: "quantity_sacks",
@@ -423,7 +400,7 @@ export const CreditNoteForm = ({
       type: "number",
       width: "110px",
       accessor: "quantity_sacks",
-      disabled: (row) => row.original_quantity_sacks <= 0 || isAnulacion,
+      disabled: (row) => row.original_quantity_sacks <= 0,
     },
     {
       id: "quantity_kg",
@@ -431,7 +408,7 @@ export const CreditNoteForm = ({
       type: "number",
       width: "100px",
       accessor: "quantity_kg",
-      disabled: (row) => row.original_quantity_kg <= 0 || isAnulacion,
+      disabled: (row) => row.original_quantity_kg <= 0,
     },
     {
       id: "unit_price",
@@ -502,7 +479,7 @@ export const CreditNoteForm = ({
 
     onSubmit({
       ...data,
-      credit_note_motive_id: watchMotiveId,
+      credit_note_motive_id: "1",
       details: details.map((r) => ({
         sale_detail_id: r.sale_detail_id,
         product_id: r.product_id,
@@ -576,15 +553,6 @@ export const CreditNoteForm = ({
             name="issue_date"
             label="FECHA DE EMISIÓN"
             placeholder="Seleccione la fecha"
-          />
-
-          <FormSelect
-            control={form.control}
-            name="credit_note_motive_id"
-            label="MOTIVO"
-            placeholder="Seleccione un motivo"
-            options={motives}
-            uppercase
           />
 
           <FormSwitch


### PR DESCRIPTION
Stop fetching and passing credit-note motives and default the motive to id "1" on submit. Remove conditional logic around the 'Anulación' motive (watching motive, disabling inputs, and preventing add/remove rows) so form rows always initialize from the selected sale and can be modified. Update CreditNoteColumns to use reason accessor and simplify sale/motive rendering (badge -> spans, motive -> Badge of reason). Adjust loading logic in add page to only depend on sales. Misc: remove motives prop from form and related options.