### PR TITLE
Rename user_id to vendedor_id and update reports nav

### DIFF
--- a/src/components/nav-data.ts
+++ b/src/components/nav-data.ts
@@ -326,13 +326,28 @@ export const navData: NavItem[] = [
     icon: ReportsIcon,
     items: [
       {
-        title: "Imprimir Tickets",
+        title: "Impresión de comprobantes",
         url: SALE_TICKETS_PRINT_ROUTE,
         icon: ReportsIcon,
       },
       {
         title: RealCustomerAccountStatementTitle,
         url: REAL_CUSTOMER_ACCOUNT_STATEMENT_ROUTE,
+        icon: ReportsIcon,
+      },
+      {
+        title: "Registro de ventas detalladas",
+        url: DETAILED_SALES_REPORT_ROUTE,
+        icon: ReportsIcon,
+      },
+      {
+        title: "Registro de Ventas (IGV)",
+        url: SALES_REGISTER_REPORT_ROUTE,
+        icon: ReportsIcon,
+      },
+      {
+        title: "Registro de Compras (IGV)",
+        url: PURCHASE_REGISTER_REPORT_ROUTE,
         icon: ReportsIcon,
       },
       { title: "Inventario", url: INVENTORY_REPORT_ROUTE, icon: ReportsIcon },
@@ -349,11 +364,6 @@ export const navData: NavItem[] = [
         icon: ReportsIcon,
       },
       {
-        title: "Ventas Detallado",
-        url: DETAILED_SALES_REPORT_ROUTE,
-        icon: ReportsIcon,
-      },
-      {
         title: "Ventas Anuales",
         url: ANNUAL_SALES_REPORT_ROUTE,
         icon: ReportsIcon,
@@ -361,16 +371,6 @@ export const navData: NavItem[] = [
       {
         title: "Ventas por Producto",
         url: SALES_BY_PRODUCT_REPORT_ROUTE,
-        icon: ReportsIcon,
-      },
-      {
-        title: "Registro de Ventas",
-        url: SALES_REGISTER_REPORT_ROUTE,
-        icon: ReportsIcon,
-      },
-      {
-        title: "Registro de Compras",
-        url: PURCHASE_REGISTER_REPORT_ROUTE,
         icon: ReportsIcon,
       },
       {

--- a/src/pages/reports/components/DetailedSalesReportPage.tsx
+++ b/src/pages/reports/components/DetailedSalesReportPage.tsx
@@ -23,7 +23,7 @@ interface FilterFormValues {
   customer_id: string;
   document_type: string;
   payment_type: string;
-  user_id: string;
+  vendedor_id: string;
   warehouse_id: string;
   start_date: string;
   end_date: string;
@@ -45,7 +45,7 @@ export default function DetailedSalesReportPage() {
       customer_id: "",
       document_type: "",
       payment_type: "",
-      user_id: "",
+      vendedor_id: "",
       warehouse_id: "",
       start_date: today,
       end_date: today,
@@ -67,7 +67,7 @@ export default function DetailedSalesReportPage() {
     payment_type:
       (values.payment_type as DetailedSalesReportParams["payment_type"]) ||
       null,
-    user_id: values.user_id ? Number(values.user_id) : null,
+    vendedor_id: values.vendedor_id ? Number(values.vendedor_id) : null,
     warehouse_id: values.warehouse_id ? Number(values.warehouse_id) : null,
     start_date: values.start_date || null,
     end_date: values.end_date || null,
@@ -213,7 +213,7 @@ export default function DetailedSalesReportPage() {
 
               <FormSelectAsync
                 control={form.control}
-                name="user_id"
+                name="vendedor_id"
                 label="Vendedor"
                 placeholder="Buscar vendedor..."
                 useQueryHook={useWorkers}

--- a/src/pages/reports/components/RealCustomerAccountStatementPage.tsx
+++ b/src/pages/reports/components/RealCustomerAccountStatementPage.tsx
@@ -30,7 +30,7 @@ import {
 } from "../lib/reports.utils";
 import { errorToast, successToast } from "@/lib/core.function";
 
-export const RealCustomerAccountStatementTitle = "Reporte Estado Cuenta Real";
+export const RealCustomerAccountStatementTitle = "Rep. créditos de vendedores";
 
 interface FilterFormValues {
   zone_id: string;

--- a/src/pages/reports/lib/reports.interface.ts
+++ b/src/pages/reports/lib/reports.interface.ts
@@ -606,7 +606,7 @@ export interface DetailedSalesReportParams {
   format?: "excel" | "pdf" | null;
   payment_type?: "CONTADO" | "CREDITO" | null;
   start_date?: string | null;
-  user_id?: number | null;
+  vendedor_id?: number | null;
   warehouse_id?: number | null;
   zone_id?: number | null;
   brand_id?: number | null;


### PR DESCRIPTION
Rename DetailedSalesReport param and form field from user_id to vendedor_id (interface, component state, form control and payload mapping). Update RealCustomerAccountStatementTitle text. Revise reports navigation: rename "Imprimir Tickets" to "Impresión de comprobantes", add report entries for "Registro de ventas detalladas", "Registro de Ventas (IGV)", and "Registro de Compras (IGV)", and remove duplicate older entries to consolidate and reorder the reports menu.