### PR TITLE
Preview delivery sheet from account page

### DIFF
--- a/src/pages/reports/components/CustomerAccountStatementPage.tsx
+++ b/src/pages/reports/components/CustomerAccountStatementPage.tsx
@@ -26,7 +26,6 @@ import { useClients } from "@/pages/client/lib/client.hook";
 import type { PersonResource } from "@/pages/person/lib/person.interface";
 import { DateRangePickerFormField } from "@/components/DateRangePickerFormField";
 import { FormSwitch } from "@/components/FormSwitch";
-import { exportCustomerAccountStatement } from "../lib/reports.actions";
 import { GroupFormSection } from "@/components/GroupFormSection";
 import PageWrapper from "@/components/PageWrapper";
 import type { Option } from "@/lib/core.interface";
@@ -35,6 +34,8 @@ import {
   calculateAccountStatementMetrics,
 } from "../lib/reports.utils";
 import { errorToast, successToast, loadingToast, dismissToast } from "@/lib/core.function";
+import { getAllSalesFiltered } from "@/pages/sale/lib/sale.actions";
+import { previewDeliverySheet } from "@/pages/deliverysheet/lib/deliverysheet.actions";
 
 export const CustomerAccountStatementTitle = "Estado de Cuenta de Clientes";
 
@@ -293,35 +294,36 @@ export default function CustomerAccountStatementPage() {
     fetch(params);
   };
 
-  const handleExport = async (exportType: "pdf") => {
+  const handleExport = async () => {
     const values = form.getValues();
     setIsExporting(true);
-    const toastId = loadingToast("Generando reporte PDF...");
+    const toastId = loadingToast("Generando planilla de reparto...");
     try {
-      const params: CustomerAccountStatementParams = {
-        zone_id: values.zone_id ? Number(values.zone_id) : null,
-        customer_id: values.customer_id ? Number(values.customer_id) : null,
-        vendedor_id: values.vendedor_id ? Number(values.vendedor_id) : null,
-        payment_type:
-          values.payment_type === "ALL"
-            ? null
-            : (values.payment_type as "CONTADO" | "CREDITO"),
-        start_date: values.start_date || null,
-        end_date: values.end_date || null,
-        query_type: values.query_type as "solo_deuda" | "todo",
-        show_old: values.show_old,
-      };
+      const paymentType =
+        values.payment_type === "ALL" ? undefined : (values.payment_type as "CONTADO" | "CREDITO");
 
-      const blob = await exportCustomerAccountStatement(params, exportType);
+      const sales = await getAllSalesFiltered({
+        customer_id: values.customer_id ? Number(values.customer_id) : undefined,
+        vendedor_id: values.vendedor_id ? Number(values.vendedor_id) : undefined,
+        payment_type: paymentType,
+        start_date: values.start_date || undefined,
+        end_date: values.end_date || undefined,
+      });
 
-      const url = window.URL.createObjectURL(blob);
+      const sale_ids = sales.map((s) => s.id);
+
+      const blob = await previewDeliverySheet({
+        type: paymentType ?? "CONTADO",
+        zone_id: values.zone_id ? Number(values.zone_id) : undefined,
+        sale_ids,
+      });
+
+      const url = URL.createObjectURL(blob);
       window.open(url, "_blank");
 
-      successToast(
-        `Reporte exportado exitosamente en formato ${exportType.toUpperCase()}`,
-      );
+      successToast("Planilla generada exitosamente");
     } catch (error) {
-      errorToast("Error al exportar el reporte");
+      errorToast("Error al generar la planilla");
       console.error(error);
     } finally {
       dismissToast(toastId);
@@ -359,7 +361,7 @@ export default function CustomerAccountStatementPage() {
                 type="button"
                 variant="outline"
                 size="sm"
-                onClick={() => handleExport("pdf")}
+                onClick={() => handleExport()}
                 disabled={isExporting}
               >
                 <Printer className="mr-2 h-4 w-4" />

--- a/src/pages/sale/lib/sale.actions.ts
+++ b/src/pages/sale/lib/sale.actions.ts
@@ -114,6 +114,15 @@ export const getAllSales = async (): Promise<SaleResource[]> => {
   return response.data;
 };
 
+export const getAllSalesFiltered = async (
+  params: Omit<GetSalesParams, "page" | "per_page">,
+): Promise<SaleResource[]> => {
+  const response = await api.get<SaleResource[]>(SALE_ENDPOINT, {
+    params: { ...params, all: true },
+  });
+  return response.data;
+};
+
 export const findSaleById = async (id: number): Promise<SaleResourceById> => {
   const response = await api.get<SaleResourceById>(`${SALE_ENDPOINT}/${id}`);
   return response.data;


### PR DESCRIPTION
Replace the previous customer account export flow with a delivery-sheet preview: fetch filtered sales, build sale_ids, and call previewDeliverySheet to generate and open the PDF. Update the export handler and button to remove the export type argument and adjust toast messages. Add getAllSalesFiltered API helper to sale.actions.ts and remove the now-unused exportCustomerAccountStatement import.