### PR TITLE
Add credit detailed sales report page

### DIFF
--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -80,6 +80,7 @@ import DeliverySheetReportPage from "@/pages/reports/components/DeliverySheetRep
 import CommissionsReportPage from "@/pages/reports/components/CommissionsReportPage";
 import CarLoadReportPage from "@/pages/reports/components/CarLoadReportPage";
 import DetailedSalesReportPage from "@/pages/reports/components/DetailedSalesReportPage";
+import CreditDetailedSalesReportPage from "@/pages/reports/components/CreditDetailedSalesReportPage";
 import SalesByProductReportPage from "@/pages/reports/components/SalesByProductReportPage";
 import AnnualSalesReportPage from "@/pages/reports/components/AnnualSalesReportPage";
 import SalesRegisterReportPage from "@/pages/reports/components/SalesRegisterReportPage";
@@ -134,6 +135,7 @@ import {
   CUSTOMER_ACCOUNT_STATEMENT_ROUTE,
   DELIVERY_SHEET_REPORT_ROUTE,
   DETAILED_SALES_REPORT_ROUTE,
+  CREDIT_DETAILED_SALES_REPORT_ROUTE,
   INVENTORY_REPORT_ROUTE,
   KARDEX_REPORT_ROUTE,
   PURCHASE_REGISTER_REPORT_ROUTE,
@@ -322,6 +324,7 @@ export function AppRoutes() {
       <Route path={COMMISSIONS_REPORT_ROUTE} element={<CommissionsReportPage />} />
       <Route path={CAR_LOAD_REPORT_ROUTE} element={<CarLoadReportPage />} />
       <Route path={DETAILED_SALES_REPORT_ROUTE} element={<DetailedSalesReportPage />} />
+      <Route path={CREDIT_DETAILED_SALES_REPORT_ROUTE} element={<CreditDetailedSalesReportPage />} />
       <Route path={ANNUAL_SALES_REPORT_ROUTE} element={<AnnualSalesReportPage />} />
       <Route path={SALES_BY_PRODUCT_REPORT_ROUTE} element={<SalesByProductReportPage />} />
       <Route path={SALES_REGISTER_REPORT_ROUTE} element={<SalesRegisterReportPage />} />

--- a/src/components/nav-data.ts
+++ b/src/components/nav-data.ts
@@ -56,6 +56,7 @@ import {
   COST_OF_SALES_REPORT_ROUTE,
   CUSTOMER_ACCOUNT_STATEMENT_ROUTE,
   DETAILED_SALES_REPORT_ROUTE,
+  CREDIT_DETAILED_SALES_REPORT_ROUTE,
   INVENTORY_REPORT_ROUTE,
   KARDEX_REPORT_ROUTE,
   PURCHASE_REGISTER_REPORT_ROUTE,
@@ -345,6 +346,11 @@ export const navData: NavItem[] = [
       {
         title: "Registro de ventas detalladas",
         url: DETAILED_SALES_REPORT_ROUTE,
+        icon: ReportsIcon,
+      },
+      {
+        title: "Registro de ventas detallado de crédito",
+        url: CREDIT_DETAILED_SALES_REPORT_ROUTE,
         icon: ReportsIcon,
       },
       {

--- a/src/pages/reports/components/CreditDetailedSalesReportPage.tsx
+++ b/src/pages/reports/components/CreditDetailedSalesReportPage.tsx
@@ -1,0 +1,257 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useBranchAsyncSearch } from "../lib/reports.hook";
+import type { DetailedSalesReportParams } from "../lib/reports.interface";
+import { Form } from "@/components/ui/form";
+import { Filter } from "lucide-react";
+import { GroupFormSection } from "@/components/GroupFormSection";
+import PageWrapper from "@/components/PageWrapper";
+import { exportDetailedSalesReport } from "../lib/reports.actions";
+import { FormSelectAsync } from "@/components/FormSelectAsync";
+import { FormSelect } from "@/components/FormSelect";
+import { DatePickerFormField } from "@/components/DatePickerFormField";
+import { useClients } from "@/pages/client/lib/client.hook";
+import ExportButtons from "@/components/ExportButtons";
+import { useBrandSearch } from "@/pages/brand/lib/brand.hook";
+import { useProduct } from "@/pages/product/lib/product.hook";
+import { useZoneSearch } from "@/pages/zone/lib/zone.hook";
+import { useWorkers } from "@/pages/worker/lib/worker.hook";
+import type { PersonResource } from "@/pages/person/lib/person.interface";
+
+interface FilterFormValues {
+  branch_id: string;
+  customer_id: string;
+  document_type: string;
+  vendedor_id: string;
+  warehouse_id: string;
+  start_date: string;
+  end_date: string;
+  zone_id: string;
+  brand_id: string;
+  product_id: string;
+  line: string;
+}
+
+export default function CreditDetailedSalesReportPage() {
+  const [isExportingExcel, setIsExportingExcel] = useState(false);
+  const [isExportingPdf, setIsExportingPdf] = useState(false);
+
+  const today = new Date().toISOString().split("T")[0];
+
+  const form = useForm<FilterFormValues>({
+    defaultValues: {
+      branch_id: "",
+      customer_id: "",
+      document_type: "",
+      vendedor_id: "",
+      warehouse_id: "",
+      start_date: today,
+      end_date: today,
+      zone_id: "",
+      brand_id: "",
+      product_id: "",
+      line: "",
+    },
+  });
+
+  const buildParams = (
+    values: FilterFormValues,
+  ): DetailedSalesReportParams => ({
+    branch_id: values.branch_id ? Number(values.branch_id) : null,
+    customer_id: values.customer_id ? Number(values.customer_id) : null,
+    document_type:
+      (values.document_type as DetailedSalesReportParams["document_type"]) ||
+      null,
+    payment_type: "CREDITO",
+    vendedor_id: values.vendedor_id ? Number(values.vendedor_id) : null,
+    warehouse_id: values.warehouse_id ? Number(values.warehouse_id) : null,
+    start_date: values.start_date || null,
+    end_date: values.end_date || null,
+    zone_id: values.zone_id ? Number(values.zone_id) : null,
+    brand_id: values.brand_id ? Number(values.brand_id) : null,
+    product_id: values.product_id ? Number(values.product_id) : null,
+    line: values.line || null,
+  });
+
+  const handleExcelExport = async () => {
+    const values = form.getValues();
+    setIsExportingExcel(true);
+    try {
+      const blob = await exportDetailedSalesReport(
+        buildParams(values),
+        "excel",
+      );
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "reporte-ventas-detallado-credito.xlsx";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+    } finally {
+      setIsExportingExcel(false);
+    }
+  };
+
+  const handlePdfExport = async () => {
+    const values = form.getValues();
+    setIsExportingPdf(true);
+    try {
+      const blob = await exportDetailedSalesReport(buildParams(values), "pdf");
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "reporte-ventas-detallado-credito.pdf";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+    } finally {
+      setIsExportingPdf(false);
+    }
+  };
+
+  return (
+    <PageWrapper>
+      <Form {...form}>
+        <div className="flex gap-4 items-start">
+          {/* LEFT: Filter card — single column */}
+          <div className="shrink-0">
+            <GroupFormSection
+              title="Filtros"
+              icon={Filter}
+              gap="gap-2"
+              cols={{ sm: 1 }}
+              horizontal
+            >
+              <FormSelectAsync
+                control={form.control}
+                name="branch_id"
+                label="Tienda"
+                placeholder="Buscar tienda..."
+                useQueryHook={useBranchAsyncSearch}
+                mapOptionFn={(item) => ({
+                  label: item.name,
+                  value: String(item.id),
+                })}
+              />
+              <FormSelect
+                control={form.control}
+                name="line"
+                label="Línea"
+                placeholder="Todas"
+                options={[
+                  {
+                    label: "ALIMENTOS BALANCEADOS",
+                    value: "ALIMENTOS BALANCEADOS",
+                  },
+                  { label: "ANIMALES VIVOS", value: "ANIMALES VIVOS" },
+                  { label: "CONCENTRADOS", value: "CONCENTRADOS" },
+                  { label: "INSUMOS", value: "INSUMOS" },
+                  { label: "MEDICAMENTOS", value: "MEDICAMENTOS" },
+                  { label: "OTROS", value: "OTROS" },
+                  { label: "PURINA", value: "PURINA" },
+                ]}
+              />
+
+              <FormSelectAsync
+                control={form.control}
+                name="brand_id"
+                label="Marca"
+                placeholder="Todas"
+                useQueryHook={useBrandSearch}
+                mapOptionFn={(item) => ({
+                  label: item.name,
+                  value: String(item.id),
+                })}
+              />
+
+              <FormSelectAsync
+                control={form.control}
+                name="zone_id"
+                label="Zona"
+                placeholder="Buscar zona..."
+                useQueryHook={useZoneSearch}
+                mapOptionFn={(item) => ({
+                  label: item.name,
+                  value: String(item.id),
+                })}
+              />
+
+              <FormSelectAsync
+                control={form.control}
+                name="customer_id"
+                label="Cliente"
+                placeholder="Buscar cliente..."
+                useQueryHook={useClients}
+                mapOptionFn={(item) => ({
+                  label:
+                    item.business_name ??
+                    `${item.names} ${item.father_surname} ${item.mother_surname}`.trim(),
+                  value: String(item.id),
+                  description: item.number_document ?? undefined,
+                })}
+              />
+
+              <FormSelectAsync
+                control={form.control}
+                name="product_id"
+                label="Producto"
+                placeholder="Buscar producto..."
+                useQueryHook={useProduct}
+                mapOptionFn={(item) => ({
+                  label: item.name,
+                  value: String(item.id),
+                  description: item.codigo ?? undefined,
+                })}
+              />
+
+              <FormSelectAsync
+                control={form.control}
+                name="vendedor_id"
+                label="Vendedor"
+                placeholder="Buscar vendedor..."
+                useQueryHook={useWorkers}
+                mapOptionFn={(item: PersonResource) => ({
+                  label:
+                    `${item.names} ${item.father_surname} ${item.mother_surname}`.trim(),
+                  description: item.number_document ?? undefined,
+                  value: String(item.id),
+                })}
+                withValue={false}
+              />
+
+              <div className="flex justify-start gap-2">
+                <DatePickerFormField
+                  control={form.control}
+                  name="start_date"
+                  label="Del"
+                  placeholder="Seleccionar fecha"
+                />
+                <DatePickerFormField
+                  control={form.control}
+                  name="end_date"
+                  label="Al"
+                  placeholder="Seleccionar fecha"
+                  autoLabelWidth
+                />
+              </div>
+
+              <div className="flex justify-end gap-2 pt-1">
+                <ExportButtons
+                  onExcelDownload={handleExcelExport}
+                  onPdfDownload={handlePdfExport}
+                  excelFileName="reporte-ventas-detallado-credito.xlsx"
+                  pdfFileName="reporte-ventas-detallado-credito.pdf"
+                  disableExcel={isExportingExcel}
+                  disablePdf={isExportingPdf}
+                />
+              </div>
+            </GroupFormSection>
+          </div>
+        </div>
+      </Form>
+    </PageWrapper>
+  );
+}

--- a/src/pages/reports/lib/reports.interface.ts
+++ b/src/pages/reports/lib/reports.interface.ts
@@ -63,6 +63,9 @@ export const CAR_LOAD_REPORT_ROUTE = `${ROUTE}/llenado-carros`;
 // Detailed Sales Report
 export const DETAILED_SALES_REPORT_ROUTE = `${ROUTE}/ventas-detallado`;
 
+// Credit Detailed Sales Report
+export const CREDIT_DETAILED_SALES_REPORT_ROUTE = `${ROUTE}/ventas-detallado-credito`;
+
 // Sales By Product Report
 export const SALES_BY_PRODUCT_REPORT_ROUTE = `${ROUTE}/ventas-por-producto`;
 


### PR DESCRIPTION
Introduce a new Credit Detailed Sales Report page and wire it into navigation and routing. Adds src/pages/reports/components/CreditDetailedSalesReportPage.tsx which provides filters, async selects, date range, and Excel/PDF export (uses exportDetailedSalesReport with payment_type set to CREDITO). Registers the new route constant CREDIT_DETAILED_SALES_REPORT_ROUTE in reports.interface.ts, adds the nav item in src/components/nav-data.ts, and imports & registers the route in src/components/AppRoutes.tsx.