### PR TITLE
Add credit note edit page and search UI

### DIFF
--- a/src/components/AppRoutes.tsx
+++ b/src/components/AppRoutes.tsx
@@ -43,6 +43,7 @@ import { SaleAddPage, SaleEditPage, SalePage } from "@/pages/sale/components";
 import SaleManagePage from "@/pages/sale/components/SaleManagePage";
 import CreditNotePage from "@/pages/credit-note/components/CreditNotePage";
 import CreditNoteAddPage from "@/pages/credit-note/components/CreditNoteAddPage";
+import CreditNoteEditPage from "@/pages/credit-note/components/CreditNoteEditPage";
 import CreditNoteManagePage from "@/pages/credit-note/components/CreditNoteManagePage";
 import GuidePage from "@/pages/guide/components/GuidePage";
 import GuideAddPage from "@/pages/guide/components/GuideAddPage";
@@ -187,7 +188,11 @@ const {
   ROUTE_ADD: DeliverySheetRouteAdd,
   ROUTE_UPDATE: DeliverySheetRouteUpdate,
 } = DELIVERY_SHEET;
-const { ROUTE: CreditNoteRoute, ROUTE_ADD: CreditNoteRouteAdd } = CREDIT_NOTE;
+const {
+  ROUTE: CreditNoteRoute,
+  ROUTE_ADD: CreditNoteRouteAdd,
+  ROUTE_UPDATE: CreditNoteRouteUpdate,
+} = CREDIT_NOTE;
 const CreditNoteManageRoutePattern = "/notas-credito/gestionar/:id";
 const {
   ROUTE: PurchaseCreditNoteRoute,
@@ -280,6 +285,7 @@ export function AppRoutes() {
       {/* Notas de crédito venta */}
       <Route path={CreditNoteRoute} element={<CreditNotePage />} />
       <Route path={CreditNoteRouteAdd} element={<CreditNoteAddPage />} />
+      <Route path={CreditNoteRouteUpdate} element={<CreditNoteEditPage />} />
       <Route path={CreditNoteManageRoutePattern} element={<CreditNoteManagePage />} />
 
       {/* Guías */}

--- a/src/pages/credit-note/components/CreditNoteEditPage.tsx
+++ b/src/pages/credit-note/components/CreditNoteEditPage.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState, useMemo, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { CreditNoteForm } from "./CreditNoteForm";
+import { type CreditNoteSchema } from "../lib/credit-note.schema";
+import {
+  ERROR_MESSAGE,
+  errorToast,
+  SUCCESS_MESSAGE,
+  successToast,
+} from "@/lib/core.function";
+import { CREDIT_NOTE } from "../lib/credit-note.interface";
+import { useCreditNoteStore } from "../lib/credit-note.store";
+import FormSkeleton from "@/components/FormSkeleton";
+import { useAllSales } from "@/pages/sale/lib/sale.hook";
+import PageWrapper from "@/components/PageWrapper";
+import type { SaleResource } from "@/pages/sale/lib/sale.interface";
+
+const { MODEL, ROUTE } = CREDIT_NOTE;
+
+export default function CreditNoteEditPage() {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const creditNoteId = Number(id);
+
+  const { fetchCreditNote, creditNote, isFinding, updateCreditNote } =
+    useCreditNoteStore();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [selectedSaleId, setSelectedSaleId] = useState<number | null>(null);
+
+  const { data: sales, isLoading: isLoadingSales } = useAllSales();
+
+  useEffect(() => {
+    if (creditNoteId) fetchCreditNote(creditNoteId);
+  }, [creditNoteId]);
+
+  useEffect(() => {
+    if (creditNote?.sale?.id) {
+      setSelectedSaleId(creditNote.sale.id);
+    }
+  }, [creditNote]);
+
+  const selectedSale = useMemo<SaleResource | null>(() => {
+    if (!sales || !selectedSaleId) return null;
+    return sales.find((s) => s.id === selectedSaleId) ?? null;
+  }, [sales, selectedSaleId]);
+
+  const salesOptions = useMemo(
+    () =>
+      sales?.map((sale) => {
+        const customer = sale.customer ?? {};
+        const name =
+          customer.names?.trim() ||
+          customer.business_name?.trim() ||
+          [customer.names, customer.father_surname, customer.mother_surname]
+            .filter((s) => typeof s === "string" && s.trim() !== "")
+            .join(" ");
+        return {
+          value: sale.id.toString(),
+          label: `${sale.serie}-${sale.numero} - ${name || ""}`,
+        };
+      }) || [],
+    [sales],
+  );
+
+  const defaultValues = useMemo<Partial<CreditNoteSchema>>(() => {
+    if (!creditNote) return {};
+    return {
+      sale_id: creditNote.sale?.id?.toString() ?? "0",
+      issue_date: creditNote.issue_date ?? "",
+      credit_note_motive_id: creditNote.credit_note_motive_id?.toString() ?? "1",
+      affects_stock: creditNote.affects_stock ?? true,
+      observations: creditNote.observations ?? "",
+      details: creditNote.details?.map((d) => ({
+        sale_detail_id: d.sale_detail_id,
+        product_id: d.product_id,
+        product_code: d.product_code ?? "",
+        product_name: d.product_name ?? "",
+        product_weight: 0,
+        original_quantity_sacks: parseFloat(d.quantity) ?? 0,
+        original_quantity_kg: 0,
+        quantity_sacks: parseFloat(d.quantity) ?? 0,
+        quantity_kg: 0,
+        unit_price: parseFloat(d.unit_price) ?? 0,
+      })) ?? [],
+    };
+  }, [creditNote]);
+
+  const handleSubmit = async (data: CreditNoteSchema) => {
+    setIsSubmitting(true);
+    try {
+      await updateCreditNote(creditNoteId, {
+        sale_id: Number(data.sale_id),
+        issue_date: data.issue_date,
+        credit_note_motive_id: Number(data.credit_note_motive_id),
+        affects_stock: data.affects_stock,
+        observations: data.observations || "",
+        details: data.details.map((detail) => ({
+          sale_detail_id: detail.sale_detail_id,
+          product_id: detail.product_id,
+          quantity_sacks: detail.quantity_sacks,
+          quantity_kg: detail.quantity_kg,
+          unit_price: detail.unit_price,
+        })),
+      });
+      successToast(SUCCESS_MESSAGE(MODEL, "update"));
+      navigate(ROUTE);
+    } catch (error: any) {
+      const message =
+        error.response?.data?.error ||
+        error.response?.data?.message ||
+        ERROR_MESSAGE(MODEL, "update");
+      errorToast(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isFinding || isLoadingSales) {
+    return (
+      <PageWrapper>
+        <FormSkeleton />
+      </PageWrapper>
+    );
+  }
+
+  if (!creditNote) {
+    return (
+      <PageWrapper>
+        <p className="text-muted-foreground">No se encontró la nota de crédito.</p>
+      </PageWrapper>
+    );
+  }
+
+  return (
+    <PageWrapper>
+      <CreditNoteForm
+        defaultValues={defaultValues}
+        onSubmit={handleSubmit}
+        onCancel={() => navigate(ROUTE)}
+        isSubmitting={isSubmitting}
+        sales={salesOptions}
+        selectedSale={selectedSale}
+        onSaleChange={setSelectedSaleId}
+        readOnlySale={true}
+      />
+    </PageWrapper>
+  );
+}

--- a/src/pages/credit-note/components/CreditNoteSearchResults.tsx
+++ b/src/pages/credit-note/components/CreditNoteSearchResults.tsx
@@ -54,8 +54,12 @@ export default function CreditNoteSearchResults({
         cell: ({ row }) => {
           const s = row.original.sale;
           return s ? (
-            <span className="font-mono">{s.serie}-{s.numero}</span>
-          ) : "—";
+            <span className="font-mono">
+              {s.serie}-{s.numero}
+            </span>
+          ) : (
+            "—"
+          );
         },
       },
       {
@@ -72,7 +76,7 @@ export default function CreditNoteSearchResults({
         header: "Estado",
         cell: ({ row }) => (
           <Badge
-            variant={row.original.status === "REGISTRADO" ? "default" : "destructive"}
+            color={row.original.status === "REGISTRADO" ? "default" : "destructive"}
             className="text-[10px]"
           >
             {row.original.status}

--- a/src/pages/credit-note/components/CreditNoteSearchResults.tsx
+++ b/src/pages/credit-note/components/CreditNoteSearchResults.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from "react";
+import { DataTable } from "@/components/DataTable";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Eye, Pencil } from "lucide-react";
+import type { ColumnDef } from "@tanstack/react-table";
+import type { CreditNoteResource } from "../lib/credit-note.interface";
+
+interface CreditNoteSearchResultsProps {
+  results: CreditNoteResource[];
+  isLoading: boolean;
+  onManage: (note: CreditNoteResource) => void;
+  onEdit: (note: CreditNoteResource) => void;
+}
+
+export default function CreditNoteSearchResults({
+  results,
+  isLoading,
+  onManage,
+  onEdit,
+}: CreditNoteSearchResultsProps) {
+  const columns = useMemo<ColumnDef<CreditNoteResource>[]>(
+    () => [
+      {
+        accessorKey: "full_document_number",
+        header: "N° Documento",
+        cell: ({ row }) => (
+          <span className="font-mono font-semibold">
+            {row.original.full_document_number}
+          </span>
+        ),
+      },
+      {
+        accessorKey: "issue_date",
+        header: "Fecha",
+        cell: ({ row }) =>
+          new Date(row.original.issue_date).toLocaleDateString("es-PE", {
+            day: "2-digit",
+            month: "2-digit",
+            year: "numeric",
+          }),
+      },
+      {
+        id: "customer",
+        header: "Cliente",
+        cell: ({ row }) => {
+          const c = row.original.customer;
+          return c?.business_name || c?.full_name || "—";
+        },
+      },
+      {
+        id: "sale",
+        header: "Venta Origen",
+        cell: ({ row }) => {
+          const s = row.original.sale;
+          return s ? (
+            <span className="font-mono">{s.serie}-{s.numero}</span>
+          ) : "—";
+        },
+      },
+      {
+        accessorKey: "total_amount",
+        header: "Total",
+        cell: ({ row }) => (
+          <span className="font-mono">
+            {parseFloat(row.original.total_amount).toFixed(2)}
+          </span>
+        ),
+      },
+      {
+        accessorKey: "status",
+        header: "Estado",
+        cell: ({ row }) => (
+          <Badge
+            variant={row.original.status === "REGISTRADO" ? "default" : "destructive"}
+            className="text-[10px]"
+          >
+            {row.original.status}
+          </Badge>
+        ),
+      },
+      {
+        id: "actions",
+        header: "Acciones",
+        cell: ({ row }) => (
+          <div className="flex items-center gap-1">
+            <Button
+              size="sm"
+              variant="outline"
+              colorIcon="blue"
+              className="h-6 px-2 text-[10px]"
+              onClick={() => onManage(row.original)}
+            >
+              <Eye className="size-3" />
+              Ver
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              colorIcon="amber"
+              className="h-6 px-2 text-[10px]"
+              onClick={() => onEdit(row.original)}
+            >
+              <Pencil className="size-3" />
+              Editar
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    [onManage, onEdit],
+  );
+
+  if (!isLoading && results.length === 0) return null;
+
+  return (
+    <div className="border-none text-muted-foreground max-w-full">
+      <DataTable
+        columns={columns}
+        data={results}
+        isLoading={isLoading}
+        getRowId={(row) => row.id.toString()}
+      />
+    </div>
+  );
+}

--- a/src/pages/sale/components/SaleOptions.tsx
+++ b/src/pages/sale/components/SaleOptions.tsx
@@ -34,6 +34,7 @@ const STATUS_OPTIONS = [
 type ActiveFilter =
   | ""
   | "documento"
+  | "nc_numero"
   | "warehouse"
   | "vendedor"
   | "document_type"
@@ -56,6 +57,8 @@ interface SaleOptionsProps {
   setEndDate: (date: Date | undefined) => void;
   documento: string;
   setDocumento: (value: string) => void;
+  nc_numero: string;
+  setNcNumero: (value: string) => void;
 }
 
 export default function SaleOptions({
@@ -75,6 +78,8 @@ export default function SaleOptions({
   setEndDate,
   documento,
   setDocumento,
+  nc_numero,
+  setNcNumero,
 }: SaleOptionsProps) {
   const { user } = useAuthStore();
   const company_id = user?.company_id;
@@ -105,6 +110,7 @@ export default function SaleOptions({
 
   const resetAllFilters = () => {
     setDocumento("");
+    setNcNumero("");
     setWarehouseId("");
     setVendedorId("");
     setDocumentType("");
@@ -150,6 +156,7 @@ export default function SaleOptions({
         <SelectContent>
           <SelectItem value="none">— Buscar por —</SelectItem>
           <SelectItem value="documento">Número de documento</SelectItem>
+          <SelectItem value="nc_numero">N° de Nota de Crédito</SelectItem>
           <SelectItem value="warehouse">Almacén</SelectItem>
           <SelectItem value="vendedor">Vendedor</SelectItem>
           <SelectItem value="document_type">Tipo de documento</SelectItem>
@@ -164,6 +171,16 @@ export default function SaleOptions({
           value={documento}
           onChange={(e) => setDocumento(e.target.value)}
           placeholder="Ej: F001-00123"
+          className="w-[160px] h-8"
+        />
+      )}
+
+      {activeFilter === "nc_numero" && (
+        <Input
+          type="text"
+          value={nc_numero}
+          onChange={(e) => setNcNumero(e.target.value)}
+          placeholder="Ej: BC01-00001"
           className="w-[160px] h-8"
         />
       )}

--- a/src/pages/sale/components/SalePage.tsx
+++ b/src/pages/sale/components/SalePage.tsx
@@ -13,6 +13,9 @@ import {
   type SaleInstallmentResource,
 } from "../lib/sale.interface";
 import { CreditNoteAddRoute } from "@/pages/credit-note/lib/credit-note.interface";
+import { getCreditNote } from "@/pages/credit-note/lib/credit-note.actions";
+import type { CreditNoteResource } from "@/pages/credit-note/lib/credit-note.interface";
+import CreditNoteSearchResults from "@/pages/credit-note/components/CreditNoteSearchResults";
 import { SimpleDeleteDialog } from "@/components/SimpleDeleteDialog";
 import {
   findSaleById,
@@ -78,6 +81,17 @@ export default function SalePage() {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const company_id = user?.company_id;
 
+  // Filtro y búsqueda de NCs por número
+  const [nc_numero, setNcNumero] = useState("");
+  const [debouncedNcNumero, setDebouncedNcNumero] = useState("");
+  const [creditNoteResults, setCreditNoteResults] = useState<CreditNoteResource[]>([]);
+  const [isLoadingCN, setIsLoadingCN] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedNcNumero(nc_numero), 400);
+    return () => clearTimeout(timer);
+  }, [nc_numero]);
+
   const { serie: parsedSerie, numero: parsedNumero } = parseDocumento(debouncedDocumento);
 
   const {
@@ -120,8 +134,20 @@ export default function SalePage() {
     per_page,
   ]);
 
+  useEffect(() => {
+    if (!debouncedNcNumero) {
+      setCreditNoteResults([]);
+      return;
+    }
+    setIsLoadingCN(true);
+    getCreditNote({ params: { full_document_number: debouncedNcNumero, per_page: 10 } })
+      .then((res) => setCreditNoteResults(res.data))
+      .catch(() => setCreditNoteResults([]))
+      .finally(() => setIsLoadingCN(false));
+  }, [debouncedNcNumero]);
+
   const { removeSale } = useSaleStore();
-  const { activeTabId, closeTab } = useWindowManager();
+  const { activeTabId, closeTab, openTab } = useWindowManager();
 
   const handleEdit = (sale: SaleResource) => {
     navigate(`/ventas/actualizar/${sale.id}`);
@@ -289,43 +315,59 @@ export default function SalePage() {
         </div>
       </div>
 
-      <SaleTable
-        columns={columns}
-        data={sales || []}
-        isLoading={isLoading}
-        enableRowSelection={true}
-        rowSelection={rowSelection}
-        onRowSelectionChange={setRowSelection}
-        onRowDoubleClick={handleEdit}
-      >
-        <SaleOptions
-          branch_id={branch_id}
-          setBranchId={setBranchId}
-          document_type={document_type}
-          setDocumentType={setDocumentType}
-          status={status}
-          setStatus={setStatus}
-          warehouse_id={warehouse_id}
-          setWarehouseId={setWarehouseId}
-          vendedor_id={vendedor_id}
-          setVendedorId={setVendedorId}
-          start_date={start_date}
-          end_date={end_date}
-          setStartDate={setStartDate}
-          setEndDate={setEndDate}
-          documento={documento}
-          setDocumento={setDocumento}
-        />
-      </SaleTable>
-
-      <DataTablePagination
-        page={page}
-        totalPages={meta?.last_page || 1}
-        onPageChange={setPage}
-        per_page={per_page}
-        setPerPage={setPerPage}
-        totalData={meta?.total || 0}
+      <SaleOptions
+        branch_id={branch_id}
+        setBranchId={setBranchId}
+        document_type={document_type}
+        setDocumentType={setDocumentType}
+        status={status}
+        setStatus={setStatus}
+        warehouse_id={warehouse_id}
+        setWarehouseId={setWarehouseId}
+        vendedor_id={vendedor_id}
+        setVendedorId={setVendedorId}
+        start_date={start_date}
+        end_date={end_date}
+        setStartDate={setStartDate}
+        setEndDate={setEndDate}
+        documento={documento}
+        setDocumento={setDocumento}
+        nc_numero={nc_numero}
+        setNcNumero={setNcNumero}
       />
+
+      {debouncedNcNumero ? (
+        <CreditNoteSearchResults
+          results={creditNoteResults}
+          isLoading={isLoadingCN}
+          onManage={(note) =>
+            openTab(`/notas-credito/gestionar/${note.id}`, note.full_document_number)
+          }
+          onEdit={(note) =>
+            openTab(`/notas-credito/actualizar/${note.id}`, note.full_document_number)
+          }
+        />
+      ) : (
+        <>
+          <SaleTable
+            columns={columns}
+            data={sales || []}
+            isLoading={isLoading}
+            enableRowSelection={true}
+            rowSelection={rowSelection}
+            onRowSelectionChange={setRowSelection}
+            onRowDoubleClick={handleEdit}
+          />
+          <DataTablePagination
+            page={page}
+            totalPages={meta?.last_page || 1}
+            onPageChange={setPage}
+            per_page={per_page}
+            setPerPage={setPerPage}
+            totalData={meta?.total || 0}
+          />
+        </>
+      )}
 
       <SimpleDeleteDialog
         open={openDelete}


### PR DESCRIPTION
Introduce CreditNoteEditPage and CreditNoteSearchResults components and wire the credit-note update route in AppRoutes. Add nc_numero filter to SaleOptions and integrate credit-note-number search into SalePage with debounced querying (getCreditNote), loading/results state, and handlers to open manage/edit tabs for found credit notes. Refactor SalePage rendering to conditionally show credit-note search results or the regular sales table and pagination; include related imports and minor state management changes.