### PR TITLE
Create person zone when missing primary on edit

### DIFF
--- a/src/pages/person/components/PersonForm.tsx
+++ b/src/pages/person/components/PersonForm.tsx
@@ -504,13 +504,23 @@ export const PersonForm = ({
             reference: (data as any).reference || "",
             is_primary: true,
           });
-        } else if (isEditing && isClient && primaryZone?.id) {
-          await updatePersonZone(primaryZone.id, {
-            zone_id: parseInt((data as any).zone_id),
-            address: (data as any).address || "",
-            reference: (data as any).reference || "",
-            is_primary: true,
-          });
+        } else if (isEditing && isClient) {
+          if (primaryZone?.id) {
+            await updatePersonZone(primaryZone.id, {
+              zone_id: parseInt((data as any).zone_id),
+              address: (data as any).address || "",
+              reference: (data as any).reference || "",
+              is_primary: true,
+            });
+          } else if ((data as any).zone_id) {
+            await createPersonZone({
+              person_id: effectivePersonId,
+              zone_id: parseInt((data as any).zone_id),
+              address: (data as any).address || "",
+              reference: (data as any).reference || "",
+              is_primary: true,
+            });
+          }
         }
 
         if (stagedAddresses.length > 0) {


### PR DESCRIPTION
When editing a client, handle the case where no primary zone exists by creating a new person zone if a zone_id is provided. Previously the code only attempted to update an existing primary zone; now it checks primaryZone?.id and either updates it or calls createPersonZone with parsed zone_id, address, reference and is_primary=true using effectivePersonId. This preserves existing update behavior while ensuring a primary zone is created when needed.